### PR TITLE
Add a variable preprocessor for variable checks

### DIFF
--- a/korte/src/commonMain/kotlin/com/soywiz/korte/ExprNode.kt
+++ b/korte/src/commonMain/kotlin/com/soywiz/korte/ExprNode.kt
@@ -9,9 +9,7 @@ interface ExprNode : DynamicContext {
 
     data class VAR(val name: String) : ExprNode {
         override suspend fun eval(context: Template.EvalContext): Any? {
-            val value = context.scope.get(name)
-            context.config.variablePreprocessor?.invoke(name, value)
-            return value
+            return context.config.variableProcessor(context, name)
         }
     }
 

--- a/korte/src/commonMain/kotlin/com/soywiz/korte/ExprNode.kt
+++ b/korte/src/commonMain/kotlin/com/soywiz/korte/ExprNode.kt
@@ -9,7 +9,9 @@ interface ExprNode : DynamicContext {
 
     data class VAR(val name: String) : ExprNode {
         override suspend fun eval(context: Template.EvalContext): Any? {
-            return context.scope.get(name)
+            val value = context.scope.get(name)
+            context.config.variablePreprocessor?.invoke(name, value)
+            return value
         }
     }
 

--- a/korte/src/commonMain/kotlin/com/soywiz/korte/TemplateConfig.kt
+++ b/korte/src/commonMain/kotlin/com/soywiz/korte/TemplateConfig.kt
@@ -34,7 +34,16 @@ open class TemplateConfig(
     fun register(vararg its: Filter) = this.apply { for (it in its) filters[it.name] = it }
     fun register(vararg its: TeFunction) = this.apply { for (it in its) functions[it.name] = it }
 
-    var variablePreprocessor: VariablePreprocessor? = null
+    var variableProcessor: VariableProcessor = { name ->
+        scope.get(name)
+    }
+
+    fun replaceVariablePocessor(func: suspend Template.EvalContext.(name: String, previous: VariableProcessor) -> Any?) {
+        val previous = variableProcessor
+        variableProcessor = { eval ->
+            this.func(eval, previous)
+        }
+    }
 
     var writeBlockExpressionResult: WriteBlockExpressionResultFunction = { value ->
         this.write(value.toEscapedString())
@@ -49,7 +58,7 @@ open class TemplateConfig(
 }
 
 typealias WriteBlockExpressionResultFunction = suspend Template.EvalContext.(value: Any?) -> Unit
-typealias VariablePreprocessor = suspend (name: String, value: Any?) -> Any?
+typealias VariableProcessor = suspend Template.EvalContext.(name: String) -> Any?
 
 open class TemplateConfigWithTemplates(
     extraTags: List<Tag> = listOf(),

--- a/korte/src/commonMain/kotlin/com/soywiz/korte/TemplateConfig.kt
+++ b/korte/src/commonMain/kotlin/com/soywiz/korte/TemplateConfig.kt
@@ -34,6 +34,8 @@ open class TemplateConfig(
     fun register(vararg its: Filter) = this.apply { for (it in its) filters[it.name] = it }
     fun register(vararg its: TeFunction) = this.apply { for (it in its) functions[it.name] = it }
 
+    var variablePreprocessor: VariablePreprocessor? = null
+
     var writeBlockExpressionResult: WriteBlockExpressionResultFunction = { value ->
         this.write(value.toEscapedString())
     }
@@ -47,6 +49,7 @@ open class TemplateConfig(
 }
 
 typealias WriteBlockExpressionResultFunction = suspend Template.EvalContext.(value: Any?) -> Unit
+typealias VariablePreprocessor = suspend (name: String, value: Any?) -> Any?
 
 open class TemplateConfigWithTemplates(
     extraTags: List<Tag> = listOf(),

--- a/korte/src/commonTest/kotlin/com/soywiz/korte/TemplateTest.kt
+++ b/korte/src/commonTest/kotlin/com/soywiz/korte/TemplateTest.kt
@@ -412,8 +412,8 @@ class TemplateTest : BaseTest() {
     @Test
     fun testCustomVariablePreprocessor() = suspendTest {
         val config = TemplateConfig().also {
-            it.variablePreprocessor = { name: String, value: Any? ->
-                if (value == null) throw NullPointerException("Variable: $name cannot be null.")
+            it.replaceVariablePocessor { name, previous ->
+                previous(name) ?: throw NullPointerException("Variable: $name cannot be null.")
             }
         }
         assertEquals("a", Template("{{ var1 }}", config)(mapOf("var1" to "a")))

--- a/korte/src/commonTest/kotlin/com/soywiz/korte/TemplateTest.kt
+++ b/korte/src/commonTest/kotlin/com/soywiz/korte/TemplateTest.kt
@@ -409,6 +409,17 @@ class TemplateTest : BaseTest() {
         expectException<NullPointerException>("null") { Template("{{ null }}", config)() }
     }
 
+    @Test
+    fun testCustomVariablePreprocessor() = suspendTest {
+        val config = TemplateConfig().also {
+            it.variablePreprocessor = { name: String, value: Any? ->
+                if (value == null) throw NullPointerException("Variable: $name cannot be null.")
+            }
+        }
+        assertEquals("a", Template("{{ var1 }}", config)(mapOf("var1" to "a")))
+        expectException<NullPointerException>("Variable: var2 cannot be null.") { Template("{{ var2 }}", config)() }
+    }
+
     @Test fun testInvalid1() = suspendTest { expectException<KorteException>("String literal not closed at template:1:3") { Template("{{ ' }}")() } }
     @Test fun testInvalid2() = suspendTest { expectException<KorteException>("No expression at template:1:3") { Template("{{ }}")() } }
     @Test fun testInvalid3() = suspendTest { expectException<KorteException>("Expected expression at template:1:5") { Template("{{ 1 + }}")() } }


### PR DESCRIPTION
As talked in slack, this is just a variable preprocessor that can handle some checks on variables. The example I did in the test:

```
it.variablePreprocessor = { name: String, value: Any? ->
   if (value == null) throw NullPointerException("Variable: $name cannot be null.")
}
```

But it could be almost anything else

```
it.variablePreprocessor = { name: String, value: Any? ->
   when (name) {
       "path" -> if (!File(value.toString()).exist()) { throw IllegalArgumentException("File Path doesn;t exist") }
       default -> {}
   }
}
```

A way of checking that the variables have the value that you expect, format or something like that.