### PR TITLE
Crash on Native when rendering a template on a background thread

### DIFF
--- a/korte/build.gradle
+++ b/korte/build.gradle
@@ -6,5 +6,6 @@ korlibs {
 
 dependencies {
     add("jvmTestImplementation", "com.vladsch.flexmark:flexmark-all:0.61.6")
+    add("nativeCommonTestApi", "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2-native-mt")
 }
 

--- a/korte/src/commonMain/kotlin/com/soywiz/korte/internal/HtmlExt.kt
+++ b/korte/src/commonMain/kotlin/com/soywiz/korte/internal/HtmlExt.kt
@@ -1,5 +1,8 @@
 package com.soywiz.korte.internal
 
+import kotlin.native.concurrent.SharedImmutable
+
+@SharedImmutable
 private val charToEntity = linkedMapOf('"' to "&quot;", '\'' to "&apos;", '<' to "&lt;", '>' to "&gt;", '&' to "&amp;")
 
 internal fun String.htmlspecialchars() = buildString {

--- a/korte/src/nativeCommonMain/kotlin/com/soywiz/korte/dynamic/ObjectMapper2Native.kt
+++ b/korte/src/nativeCommonMain/kotlin/com/soywiz/korte/dynamic/ObjectMapper2Native.kt
@@ -1,5 +1,7 @@
 package com.soywiz.korte.dynamic
 
+import kotlin.native.concurrent.SharedImmutable
+
 // @TODO: Hopefully someday: https://github.com/Kotlin/kotlinx.serialization/tree/dev
 open class NativeObjectMapper2 : ObjectMapper2() {
     //override fun hasProperty(instance: Any, key: String): Boolean = TODO("Not supported in native yet")
@@ -9,4 +11,5 @@ open class NativeObjectMapper2 : ObjectMapper2() {
     //override suspend fun get(instance: Any, key: Any?): Any? = TODO("Not supported in native yet")
 }
 
+@SharedImmutable
 actual val Mapper2: ObjectMapper2 = NativeObjectMapper2()

--- a/korte/src/nativeCommonTest/kotlin/com/soywiz/korte/MultiThreadingTests.kt
+++ b/korte/src/nativeCommonTest/kotlin/com/soywiz/korte/MultiThreadingTests.kt
@@ -1,0 +1,23 @@
+package com.soywiz.korte
+
+import com.soywiz.korte.dynamic.DynamicType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MultiThreadingTests {
+
+    @Test
+    fun testTemplateEvaluationOnBackgroundThread() = runBlocking {
+        data class Model(val x: Int) : DynamicType<Model> by DynamicType({
+            register(Model::x)
+        })
+        withContext(Dispatchers.Default) {
+            val template = Template("{{x+1}}")
+            val rendered = template(Model(x = 2))
+            assertEquals("3", rendered)
+        }
+    }
+}


### PR DESCRIPTION
- Mark GlobalProperties as SharedImmutable
- Add a test that renders the template on a background thread.

Fixes #16 